### PR TITLE
bugfix: remove bug que crashava o programa

### DIFF
--- a/projects/generic-trello/batman/app/src/pages/Register/index.js
+++ b/projects/generic-trello/batman/app/src/pages/Register/index.js
@@ -56,7 +56,7 @@ export default function SignUp() {
         window.location = "/"
       }, 2500);
     }).catch(err => {
-      setResAPI(err)
+      setResAPI(err.message)
       setSeverity('error')
       setOpen(true)
     })


### PR DESCRIPTION
Ao tentar registrar um usuário com dados inválidos, o programa crashava e não realizava a requisição